### PR TITLE
Fix media directory ownership for appuser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy app
 COPY app.py ./app.py
 
-# Create media dir for outputs
-RUN mkdir -p /app/media
-
 # Non-root (optional)
 RUN useradd -ms /bin/bash appuser
+
+# Create media dir for outputs
+RUN mkdir -p /app/media && chown appuser:appuser /app/media
+
 USER appuser
 
 ENV PORT=5050


### PR DESCRIPTION
## Summary
- ensure /app/media directory is owned by non-root appuser

## Testing
- `python -m py_compile app.py`
- `docker build -t meditrack-opencv:latest .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d691c45c08324ad57283f1b76f3e7