### PR TITLE
Allow custom FFmpeg path with availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ to track camera rotation between frames. Frames are sampled with
 for OCR.
 
 System-level `ffmpeg` must be available; the supplied `Dockerfile` installs it.
+Set the optional `FFMPEG_PATH` environment variable if the binary is not on
+`PATH`. The `/unwrap` endpoint checks for FFmpeg and returns a descriptive
+error if it cannot be found.
 
 ## Debugging
 Include `debug=1` as a query parameter on `/unwrap` requests to save

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import uuid
 import tempfile
 import traceback
 import subprocess
+import shutil
 from pathlib import Path
 from typing import Tuple, Optional, Any, List
 
@@ -560,10 +561,13 @@ def unwrap():
 
     try:
         with tempfile.TemporaryDirectory() as frame_dir:
+            ffmpeg_cmd = os.getenv("FFMPEG_PATH", "ffmpeg")
+            if not shutil.which(ffmpeg_cmd):
+                abort(500, description="FFmpeg not found; install it or set FFMPEG_PATH.")
             # Extract one frame per second using FFmpeg
             subprocess.run(
                 [
-                    "ffmpeg",
+                    ffmpeg_cmd,
                     "-i",
                     tmp_path,
                     "-vf",


### PR DESCRIPTION
## Summary
- Allow configuring FFmpeg path via `FFMPEG_PATH` env var
- Check for FFmpeg availability and return descriptive error
- Document optional `FFMPEG_PATH` and error behavior in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689d7297695483248220fcf7a5993efd